### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Usage
 -----
 Create a bookmarklet with the following URL:
 ```js
-javascript:$.getScript("https://rawgit.com/JTBrinkmann/Dubtrack-Playlist-Pusher/master/index.js");void(8)
+javascript:$.getScript("https://combinatronics.com/JTBrinkmann/Dubtrack-Playlist-Pusher/master/index.js");void(8)
 ```
 
 Give it any name (e.g. "Dubtrack Playlist Pusher"). Then go to Dubtrack (make sure you're logged in) and click the bookmarklet.


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.